### PR TITLE
Custom render pattern in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ use `ctrl + v` to paste images from the clipboard when writing markdown.
 
 ## Release Notes
 
+### 2.4.0
+
+- feature: custom render pattern
+
 ### 2.3.0
 
 compress image successfully

--- a/package.json
+++ b/package.json
@@ -53,6 +53,11 @@
           "default": "${currentFileDir}",
           "description": "The base path of image url.You can use variable ${currentFileDir} and ${projectRoot}. ${currentFileDir} will be replace by the path of directory that contain current editing file. ${projectRoot} will be replace by path of the project opened in vscode. If you set basePath to empty String, it will insert absolute path to file."
         },
+        "mdPasteEnhanced.renderPattern": {
+          "type": "string",
+          "default": "![](${imagePath})",
+          "description": "The base path of image url. The ${imagePath} is the path relative to the base path."
+        },
         "mdPasteEnhanced.ImageType": {
           "type": "string",
           "default": ".png",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "md-paste-enhanced",
   "displayName": "markdown paste enhanced",
   "description": "use ctrl+v to paste image directly in markdown",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "engines": {
     "vscode": "^1.71.0"
   },

--- a/src/config.js
+++ b/src/config.js
@@ -98,4 +98,9 @@ module.exports = {
   get compressThreshold() {
     return compressThreshold;
   },
+  get renderPattern() {
+    return vscode.workspace.getConfiguration("mdPasteEnhanced")[
+      "renderPattern"
+    ];
+  },
 };

--- a/src/main.js
+++ b/src/main.js
@@ -83,7 +83,7 @@ function render(basePath, filePath) {
     filePath = path.relative(basePath, filePath).replace(/\\/g, "/");
   }
   filePath = encodeURI(filePath);
-  let imageLink = `![](${filePath})`;
+  let imageLink = getImageLink(filePath);
   // vscode.env.clipboard.writeText(imageLink); // 似乎会打断saveImage的执行, 提早改变剪切板, 除非用await
   // vscode.commands.executeCommand("editor.action.clipboardPasteAction");
   let editor = vscode.window.activeTextEditor;
@@ -96,6 +96,16 @@ function render(basePath, filePath) {
       edit.replace(current, imageLink);
     }
   });
+  return;
+  function getImageLink(imagePath) {
+    let renderPattern = config.renderPattern;
+    return replaceVariables(renderPattern);
+    function replaceVariables(pattern) {
+      return pattern.replace(/\$\{imagePath\}/g, (match, src) => {
+        return imagePath;
+      });
+    }
+  }
 }
 
 class PluginError {


### PR DESCRIPTION
My friend prefer such render style: `<img src="/path/to/image" width="60%"/>`, which looks prettier in the markdown.