### PR TITLE
Apply newline replacement in renderPattern to support multi-line image code blocks in reStructuredText (RST) files.

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -36,8 +36,11 @@ class Config {
     const matchedPattern = this.renderMap.find((item) => {
       return minimatch(filePath, item.matchRule);
     });
-    return matchedPattern.renderPattern ?? this.renderPatternDeprecated;
-  }
+
+    // Apply the replacement so that \n is converted to a real newline
+    const pattern = matchedPattern?.renderPattern ?? this.renderPatternDeprecated;
+    return pattern.replace(/\\n/g, '\n');
+}
 
   get matchPattern() {
     return convertPatternToReg(this.renderPattern);


### PR DESCRIPTION
Applies newline replacement in renderPattern to support multi-line image code blocks in reStructuredText (RST) files

In RST files, image code blocks often need to span multiple lines, which was previously unsupported. This change may also benefit other formats that require multi-line syntax in the render pattern.

For example, you can now use a render map with \n like:

`
**/*.rst => .. image::  ${imagePath}\n    :class: browser-screenshot with-shadow\n    :alt: ${imagePath}
`

Reference: [RST image directive documentation](https://docutils.sourceforge.io/docs/ref/rst/directives.html#image)