### PR TITLE
Support multi-root workspace

### DIFF
--- a/src/builtInVar.js
+++ b/src/builtInVar.js
@@ -8,7 +8,9 @@ const theVars = {
     return path.dirname(filePath);
   },
   get projectRoot() {
-    return vscode.workspace.workspaceFolders[0].uri.fsPath;
+    const defaultWorkspace = vscode.workspace.workspaceFolders[0];
+    const activeWorkspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri);
+    return activeWorkspaceFolder ? activeWorkspaceFolder.uri.fsPath : defaultWorkspace.uri.fsPath;
   },
   get currentFileName() {
     const editor = vscode.window.activeTextEditor;


### PR DESCRIPTION
### Features Implemented

- `${projectRoot}` pattern does not work well with [multi-root workspaces](https://code.visualstudio.com/docs/editor/multi-root-workspaces).
- Generalize workspace selection from just selecting first workspace to selecting active workspace.

### Tests

I have tested by installing VISX file built from my fork.

It successfuly selects active workspace under following settings.
![image](https://github.com/user-attachments/assets/127cd863-8d4e-4638-ad53-e51ae7d1dafc)

Before this PR, it only creates images inside first workspace 'cds'.
![image](https://github.com/user-attachments/assets/2b2ce556-46ee-4f74-8e49-ae7ce2432a91)
