### PR TITLE
Fix platform detection error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "md-paste-enhanced",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "md-paste-enhanced",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "license": "MIT",
       "dependencies": {
         "is-wsl": "^3.1.0",

--- a/src/clipboard/clipboard.js
+++ b/src/clipboard/clipboard.js
@@ -3,15 +3,17 @@ const ClipboardWin = require("./win32.js");
 const ClipboardWSL = require("./wsl.js");
 const ClipboardMac = require("./mac.js");
 const PluginError = require("../error.js");
+
 function Clipboard() {
   const platform = process.platform;
-  if (platform == "win32") {
+  const isActuallyWsl = isWsl.default || isWsl;
+  if (platform === "win32") {
     return new ClipboardWin();
-  } else if (isWsl) {
+  } else if (isActuallyWsl === true) {
     return new ClipboardWSL();
-  } else if (platform == "darwin") {
+  } else if (platform === "darwin") {
     return new ClipboardMac();
-  } else if (platform == "linux") {
+  } else if (platform === "linux") {
     throw new PluginError("under development");
   } else {
     throw new PluginError("unknown platform")


### PR DESCRIPTION
The `is-wsl` package uses ES6 export. When required in CommonJS, the `isWsl` variable is interpreted as an object `{ default: true }`. This causes the condition for detecting WSL to always evaluate to true, leading to errors on macOS and potentially other platforms (Related: https://github.com/dzylikecode/Inspire-VSCodeExt-Paste-Image/issues/31).

This PR fixes this issue by using `===` for platform checks to make OS detection more robust.