### PR TITLE
Fix imagePath formatting in getImageLink function

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -26,8 +26,8 @@ function render(basePath, filePath) {
   function getImageLink(imagePath) {
     let renderPattern = config.renderPattern;
     return calcPathVariables(renderPattern, {
-      imagePath: imagePath,
-    }).replace(/\\/g, "/");
+      imagePath: imagePath.replace(/\\/g, "/"),
+    });
   }
 }
 


### PR DESCRIPTION
Some patters include backslashes, like inserting an image in latex code:

\includegraphics{${imagePath}}

So only replacement on the path is needed instead of the whole pattern